### PR TITLE
Fix empty buff commands

### DIFF
--- a/lua/file-actions-nvim/buffer_change_handler.lua
+++ b/lua/file-actions-nvim/buffer_change_handler.lua
@@ -4,7 +4,7 @@ vim.api.nvim_create_autocmd({"BufNewFile", "BufRead"}, {
     local extension, _ = vim.api.nvim_buf_get_name(0):gsub(".*%.", "")
     local ft = Filetypes[extension]
     for ftypes, act in pairs(Actions) do
-        if ft == ftypes or ftypes == 'universal' then
+        if ft == ftypes then
             for _, command in pairs(act) do
                 vim.api.nvim_create_user_command('FileActions' .. command[1], function(opts)
                 command[2](extension)

--- a/lua/file-actions-nvim/buffer_change_handler.lua
+++ b/lua/file-actions-nvim/buffer_change_handler.lua
@@ -1,16 +1,18 @@
 vim.api.nvim_create_autocmd({"BufNewFile", "BufRead"}, {
-  pattern = "*",
-  callback = function()
-    local extension, _ = vim.api.nvim_buf_get_name(0):gsub(".*%.", "")
-    local ft = Filetypes[extension]
-    for ftypes, act in pairs(Actions) do
-        if ft == ftypes then
-            for _, command in pairs(act) do
-                vim.api.nvim_create_user_command('FileActions' .. command[1], function(opts)
-                command[2](extension)
-                end, {})
-            end
-        end
-    end
-  end,
+	pattern = "*",
+	callback = function()
+		local extension, _ = vim.api.nvim_buf_get_name(0):gsub(".*%.", "")
+		local ft = Filetypes[extension]
+		local command_name
+		for ftypes, act in pairs(Actions) do
+			if ft == ftypes then
+				for _, command in pairs(act) do
+					command_name = 'FileActions' .. command[1]
+					vim.api.nvim_buf_create_user_command(0, command_name, function(opts)
+						command[2](extension)
+					end, {})
+				end
+			end
+		end
+	end,
 })

--- a/lua/file-actions-nvim/init.lua
+++ b/lua/file-actions-nvim/init.lua
@@ -4,7 +4,15 @@ Handler = require('file-actions-nvim.buffer_change_handler')
 local M = {}
 
 function M.setup()
-
+	for ftypes, act in pairs(Actions) do
+		if ftypes == 'universal' then
+			for _, command in pairs(act) do
+				vim.api.nvim_create_user_command('FileActions' .. command[1], function(opts)
+					command[2]()
+				end, {})
+			end
+		end
+	end
 end
 
 return M


### PR DESCRIPTION
closes #2 

1. User created commands are now mapped to a current buffer (not globally).
This prevents from keeping commands assigned to previous buffer.
2. Universal commands are now created at initialization. 
So universal commands commands are created only once at startup. 